### PR TITLE
Filter out "channels and roles" / "browse channels" from <mentions>

### DIFF
--- a/index.js
+++ b/index.js
@@ -211,7 +211,7 @@ bot.once('ready', async () => {
     ]);
 });
 
-let validQuery = q => !(q.startsWith('@') || q.startsWith('#') || q.startsWith(':') || q.startsWith('/') || q.startsWith('a:') || q.startsWith('t:') || q.startsWith('http') || q == 'init' || q.length <= 0);
+let validQuery = q => !(q.startsWith('@') || q.startsWith('#') || q.startsWith(':') || q.startsWith('/') || q.startsWith('a:') || q.startsWith('t:') || q.startsWith('id:') || q.startsWith('http') || q == 'init' || q.length <= 0);
 async function getEmbeds(msg, edit=true) {
     if (msg.content.includes('`')) return 0;
     let queries = [...msg.content.matchAll(/(?<=(^|[^\\]))((\<(.*?)\>)|(\[\[(.*?)\]\]))/g)];


### PR DESCRIPTION
Those are two special channel-like categories now available to larger discord servers, stored internally in discord as `<id:customize>` and `<id:browse>` respectively. Linking either in a message currently results in an empty reply from slaytabase.